### PR TITLE
Fixing P/T Regex and adding retry logic for RestClient

### DIFF
--- a/lib/card_extractor.rb
+++ b/lib/card_extractor.rb
@@ -46,7 +46,18 @@ module MTGExtractor
     end
     
     def get_card_details
-      response = RestClient.get(url)
+      success = false
+
+      # retry getting card details until successful
+      while success == false
+        begin
+          response = RestClient.get(url)
+          success = true
+        rescue
+          sleep 2
+          puts "RETRYING get_card_details..."
+        end
+      end
       @card_details['page_html']          = convert_to_utf_8(response)
 
       parse_page

--- a/lib/mtgextractor/rails/tasks/mtgextractor.rake
+++ b/lib/mtgextractor/rails/tasks/mtgextractor.rake
@@ -131,7 +131,18 @@ def download_set_icon(card, set, gatherer_symbol_url)
     full_path = "#{Rails.root}/public/images/#{set.folder_name}/#{slugify(card.rarity)}_icon.jpg"
   end
   unless File.exists?(full_path)
-    image_data = RestClient.get(gatherer_symbol_url)
+    success = false
+
+    # retry downloading the set icon
+    while success == false
+      begin
+        image_data = RestClient.get(gatherer_symbol_url)
+        success = true
+      rescue
+        sleep 2
+        puts "RETRYING download_set_icon..."
+      end
+    end
     File.open(full_path, "wb") do |f|
       f.write(image_data)
     end
@@ -139,7 +150,18 @@ def download_set_icon(card, set, gatherer_symbol_url)
 end
 
 def download_card_image(card, set)
-  image_data = RestClient.get(card.gatherer_image_url)
+  success = false
+
+  # retry downloading card image until successful
+  while success == false
+    begin
+      image_data = RestClient.get(card.gatherer_image_url)
+      success = true
+    rescue
+      sleep 2
+      puts "RETRYING download_card_image..."
+    end
+  end
   if using_asset_pipeline?
     full_path = "#{Rails.root}/app#{asset_pipeline_prefix}/images/#{set.folder_name}/#{card.multiverse_id}.jpg"
   else

--- a/lib/set_extractor.rb
+++ b/lib/set_extractor.rb
@@ -19,7 +19,18 @@ module MTGExtractor
 
     def get_card_urls
       ids = []
-      response = RestClient.get(@url,:cookies => {:CardDatabaseSettings => "11=7"})
+
+      # retry getting card urls until successful
+      success = false
+      while success == false
+        begin
+          response = RestClient.get(@url,:cookies => {:CardDatabaseSettings => "11=7"})
+          success = true
+        rescue
+          sleep 2
+          puts "RETRYING get_card_urls..."
+        end
+      end
       extract_card_urls(response)
     end
 
@@ -30,7 +41,7 @@ module MTGExtractor
     end
 
     def self.get_all_sets
-      response = RestClient.get('http://gatherer.wizards.com/Pages/Default.aspx')
+      response = RestClient.get('http://gatherer.wizards.com')
       set_select_regex = /<select name="ctl00\$ctl00\$MainContent\$Content\$SearchControls\$setAddText" id="ctl00_ctl00_MainContent_Content_SearchControls_setAddText">\s*(<option[^>]*>[^>]*<\/option>\s*)+<\/select>/
       set_regex = /value="([^"]+)"/
 


### PR DESCRIPTION
It looked like the Power and Toughness regular expressions were not working correctly, so I have modified them a bit and appears to be working again. I was also have issues with the RestClient throwing internal server errors, so I added retry logic in the case of connection failure. This has allowed me to process all the sets without error.
